### PR TITLE
Fixed crashing on start when use blueprints configuration in config

### DIFF
--- a/src/0.8/main.py
+++ b/src/0.8/main.py
@@ -47,7 +47,7 @@ def configure_blueprints(app, blueprints):
 
         if (isinstance(blueprint_config, basestring)):
             blueprint = blueprint_config
-        elif (isinstance(blueprint_config, dict)):
+        elif (isinstance(blueprint_config, tuple)):
             blueprint = blueprint_config[0]
             kw = blueprint_config[1]
 


### PR DESCRIPTION
like ('blog.views.app', {'url_prefix':'/blog'})

main.py", line 7, in __import_blueprint
    split = blueprint_str.split('.')
AttributeError: 'NoneType' object has no attribute 'split
