### PR TITLE
Using module name as app_name by default

### DIFF
--- a/examples/blog_example/main.py
+++ b/examples/blog_example/main.py
@@ -17,7 +17,7 @@ def config_str_to_obj(cfg):
 
 
 def app_factory(config, app_name=None, blueprints=None):
-    app_name = app_name or __name__
+    app_name = app_name or __name__.split('.')[0]
     app = Flask(app_name)
 
     config = config_str_to_obj(config)

--- a/src/main.py
+++ b/src/main.py
@@ -25,7 +25,7 @@ def config_str_to_obj(cfg):
 
 
 def app_factory(config, app_name=None, blueprints=None):
-    app_name = app_name or __name__
+    app_name = app_name or __name__.split('.')[0]
     app = Flask(app_name)
 
     config = config_str_to_obj(config)


### PR DESCRIPTION
Please, read the subsession **About the First Parameter** from [1].
As you can see, the documentation recommends use the module and
`__name__` is only recommended for single module app.

``` python
app = Flask('yourapplication')
app = Flask(__name__.split('.')[0])
```

1 - http://flask.pocoo.org/docs/api/#flask.Flask
