### PR TITLE
Update config.py - reference to 'app'

### DIFF
--- a/{{ cookiecutter.repo_name }}/config.py
+++ b/{{ cookiecutter.repo_name }}/config.py
@@ -58,8 +58,8 @@ class Config(object):
     ]
 
     # see example/ for reference
-    # ex: BLUEPRINTS = ['blog']  # where app is a Blueprint instance
-    # ex: BLUEPRINTS = [('blog', {'url_prefix': '/myblog'})]  # where app is a Blueprint instance
+    # ex: BLUEPRINTS = ['blog']  # where `blog` is a Blueprint instance
+    # ex: BLUEPRINTS = [('blog', {'url_prefix': '/myblog'})]  # where `blog` is a Blueprint instance
     BLUEPRINTS = []
 
 


### PR DESCRIPTION
The original text in the config file has comments saying `# ex: BLUEPRINTS = ['blog']  # where app is a Blueprint instance`.

Nothing on the line or in the lines nearby makes a reference to `app` - should the term `app` be changed to `blog`? Or am I misunderstanding the meaning of the comment? If I am misunderstanding, what could be done to make the comment more clear?