### PR TITLE
Update depcrecated flask.ext.mongoengine.

### DIFF
--- a/{{ cookiecutter.repo_name }}/extensions.py
+++ b/{{ cookiecutter.repo_name }}/extensions.py
@@ -15,7 +15,7 @@ db = SQLAlchemy()
 
 
 {%- if cookiecutter.use_nosql == 'yes' %}
-from flask.ext.mongoengine import MongoEngine
+from flask_mongoengine import MongoEngine
 nosql = MongoEngine()
 
 {% endif %}


### PR DESCRIPTION
Fixes the error
```
from flask.ext.mongoengine import MongoEngine
ModuleNotFoundError: No module named 'flask.ext'
```

when configuring to use nosql